### PR TITLE
feat/api-authentication

### DIFF
--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Self
+
+from src.api.jwt import JWTHandler
+from src.command.commands.base import UserID
+from src.command.commands.users import UserGetByID, UserRole
+from src.command.repositories.users import UserRespository
+from src.exceptions import UnAuthenticated, UnauthorizedError
+
+
+
+@dataclass
+class UserContext:
+    user_id: UserID
+    role: UserRole
+    
+    def validate_role(self, role: UserRole) -> Self:
+        if self.role != UserRole(role).value:
+            raise UnauthorizedError(
+                message=f"Permission Denied: '{role.value}' only."
+            )
+        return self
+
+
+class AuthenticationService:
+    
+    def __init__(
+        self,
+        user_repo: UserRespository,
+        jwt_handler: JWTHandler
+    ) -> None:
+        
+        self.user_repo = user_repo
+        self.jwt_handler = jwt_handler
+
+    
+    async def authenticate(self, token: str) -> UserContext:
+        jwt_payload = self.jwt_handler.decode_jwt_token(token=token)
+        # Get user from the user id.
+        user = await self.user_repo.get(UserGetByID(id=jwt_payload.user_id))
+        
+        if user is None:
+            raise UnAuthenticated(message=f"No user found with this user id: {jwt_payload.user_id}")
+        
+        return UserContext(user_id=jwt_payload.user_id, role=jwt_payload.role)
+ 

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,11 +1,13 @@
 from typing import Annotated, Optional
 from fastapi import Depends, Cookie
-from src.api.jwt import JWTHandler, JWTPayload
+from src.api.auth import AuthenticationService, UserContext
+from src.api.jwt import JWTHandler
 from src.command.commands.base import UserID
+from src.command.commands.users import UserRole
 from src.dependencies import (
     user_service, course_service, module_service, 
     lesson_service, media_service, assignment_service, jwt_handler,
-    enrollment_service, assignment_submission_service
+    enrollment_service, assignment_submission_service, user_repository
 )
 from src.dependencies import (
     UserService, CourseService, ModuleService,
@@ -13,9 +15,10 @@ from src.dependencies import (
     EnrollmentService, AssignmentSubmissionService
     
 )
-from src.exceptions import UnAuthenticated
+from src.exceptions import UnAuthenticated, UnauthorizedError
 
-# Helper functions to build a Services used for Depedency Injection.
+
+# # Helper functions to build a Services used for Depedency Injection.
 
 def get_user_service() -> UserService:
     return user_service
@@ -58,23 +61,42 @@ EnrollmentServiceDependency = Annotated[EnrollmentService, Depends(get_enrollmen
 AssignmentSubmissionServiceDependency = Annotated[AssignmentSubmissionService, Depends(get_assignment_submission_service)]
 
 
-async def get_current_user(
-    jwt_handler: Annotated[JWTHandler, Depends(get_jwt_handler)],
-    access_token: Annotated[Optional[str], Cookie()] = None,
-) -> JWTPayload:
-    
-    if access_token is None:
-        raise UnAuthenticated(message="Missing access token.")
-    
-    try:
-        payload = jwt_handler.decode_jwt_token(access_token)
-        return payload.user_id
-    
-    except Exception: 
-        raise UnAuthenticated(message="Invalid or Expired token.")
+
+authentication_service = AuthenticationService(
+    user_repo=user_repository,
+    jwt_handler=jwt_handler
+)
+
+async def get_current_user_context(
+    access_token: Annotated[
+        Optional[str], Cookie()] = None
+    ) -> UserContext:
+    user_context = await authentication_service.authenticate(token=access_token)
+    return user_context
     
 
+UserContextDependency = Annotated[UserContext, Depends(get_current_user_context)]
+
+async def get_current_user(user_context: UserContextDependency) -> UserID:
+    return user_context.user_id
+
+async def get_current_trainee(user_context: UserContextDependency) -> UserID:
+    return user_context.validate_role(UserRole.TRAINEE).user_id
+
+async def get_current_trainer(user_context: UserContextDependency) -> UserID:
+    return user_context.validate_role(UserRole.TRAINER).user_id
+
+async def get_current_admin(user_context: UserContextDependency) -> UserID:
+    return user_context.validate_role(UserRole.ADMIN).user_id
+
+async def get_current_admin_or_trainer(user_context: UserContextDependency) -> UserID:
+    if not (user_context.role == UserRole.ADMIN or user_context.role == UserRole.TRAINER):
+        raise UnauthorizedError(message=f"Permission Denied: {UserRole.ADMIN.value} or {UserRole.TRAINER.value} required.")
+    return user_context.user_id
 
 CurrentUser = Annotated[UserID, Depends(get_current_user)]
-
+CurrentTrainee = Annotated[UserID, Depends(get_current_trainee)]
+CurrentTrainer = Annotated[UserID, Depends(get_current_trainer)]
+CurrentAdmin = Annotated[UserID, Depends(get_current_admin)]
+CurrentAdminOrTrainer = Annotated[UserID, Depends(get_current_admin_or_trainer)]
 

--- a/src/api/jwt.py
+++ b/src/api/jwt.py
@@ -42,6 +42,6 @@ class JWTHandler:
         try:
             payload = jwt.decode(token, key="secret", algorithms=["HS256"])
             return JWTPayload(**payload)
-        except jwt.PyJWKError:
+        except jwt.PyJWTError:
             raise UnAuthenticated(message="Invalid or Expired token.")
         

--- a/src/command/services/users.py
+++ b/src/command/services/users.py
@@ -107,9 +107,9 @@ class UserService(BaseService[User]):
     @require_authorization(
         action=Action.VIEW,
         entity=Entity.USER,
-        user_id_field="viwer_id",
+        user_id_field="viewer_id",
         entity_id_field="id",
-        object_name="cmd"
+        object_name="query"
     )
     @override
     async def get(self, query: UserGetByIDQuery) -> User:


### PR DESCRIPTION
feat(api): add authentication service and role-based access dependencies

Introduce a dedicated AuthenticationService in the API layer to handle
JWT authentication and user validation for REST endpoints.

Key changes:

* Added `src/api/auth.py` containing:

  * `AuthenticationService` responsible for validating JWT tokens and retrieving users.
  * `UserContext` dataclass representing the authenticated user and their role.
  * `validate_role()` helper for role-based authorization checks.
* Implemented API-layer dependency `get_current_user_context` to authenticate
  users via access token stored in cookies.
* Added role-specific FastAPI dependencies:

  * `CurrentUser`
  * `CurrentTrainee`
  * `CurrentTrainer`
  * `CurrentAdmin`
  * `CurrentAdminOrTrainer`
* These dependencies enforce role-based access control directly at the API layer.

Purpose:
Role validation previously existed only at the service layer to keep
services application-agnostic. Since services are now exposed through
HTTP REST APIs, authorization checks are also introduced in the API
layer to enforce endpoint-level access control.

Note:
Temporary double validation may occur between API and service layers.
This will be optimized in future updates using Redis caching to reduce
repeated lookups.
